### PR TITLE
port tinyx to libXfont2

### DIFF
--- a/Xext/xf86bigfont.c
+++ b/Xext/xf86bigfont.c
@@ -179,7 +179,7 @@ XFree86BigfontExtensionInit()
             + (unsigned int) (65536.0 / (RAND_MAX + 1.0) * rand());
         /* fprintf(stderr, "signature = 0x%08X\n", signature); */
 
-        FontShmdescIndex = AllocateFontPrivateIndex();
+        FontShmdescIndex = xfont2_allocate_font_private_index();
 
 #if !defined(CSRG_BASED) && !defined(__CYGWIN__)
         pagesize = SHMLBA;
@@ -511,7 +511,7 @@ ProcXF86BigfontQueryFont(ClientPtr client)
             }
             if (pDesc && !badSysCall) {
                 *(CARD32 *) (pCI + nCharInfos) = signature;
-                if (!FontSetPrivate(pFont, FontShmdescIndex, pDesc)) {
+                if (!xfont2_font_set_private(pFont, FontShmdescIndex, pDesc)) {
                     shmdealloc(pDesc);
                     return BadAlloc;
                 }

--- a/configure.ac
+++ b/configure.ac
@@ -319,7 +319,7 @@ XEXTXORG_LIB='$(top_builddir)/Xext/libXextbuiltin.la'
 
 dnl Core modules for most extensions, et al.
 REQUIRED_MODULES="[randrproto >= 1.2] renderproto [fixesproto >= 4.0] [damageproto >= 1.1] xcmiscproto xextproto xproto xtrans xf86bigfontproto [scrnsaverproto >= 1.1] bigreqsproto resourceproto fontsproto inputproto [kbproto >= 1.0.3]"
-REQUIRED_LIBS="xfont fontenc"
+REQUIRED_LIBS="xfont2 fontenc"
 
 AM_CONDITIONAL(SCREENSAVER, [test "x$SCREENSAVER" = xyes])
 if test "x$SCREENSAVER" = xyes; then

--- a/dix/dispatch.c
+++ b/dix/dispatch.c
@@ -1388,7 +1388,7 @@ ProcQueryTextExtents(register ClientPtr client)
             return (BadLength);
         length--;
     }
-    if (!QueryTextExtents(pFont, length, (unsigned char *) &stuff[1], &info))
+    if (!xfont2_query_text_extents(pFont, length, (unsigned char *) &stuff[1], &info))
         return (BadAlloc);
     reply.type = X_Reply;
     reply.length = 0;

--- a/dix/main.c
+++ b/dix/main.c
@@ -292,7 +292,7 @@ main(int argc, char *argv[], char *envp[])
 
         InitAtoms();
         InitEvents();
-        InitGlyphCaching();
+        xfont2_init_glyph_caching();
         ResetExtensionPrivates();
         ResetClientPrivates();
         ResetScreenPrivates();
@@ -300,7 +300,9 @@ main(int argc, char *argv[], char *envp[])
         ResetGCPrivates();
         ResetPixmapPrivates();
         ResetColormapPrivates();
+#if 0
         ResetFontPrivateIndex();
+#endif
         ResetDevicePrivateIndex();
         InitCallbackManager();
         InitVisualWrap();

--- a/include/dixfont.h
+++ b/include/dixfont.h
@@ -28,13 +28,14 @@ SOFTWARE.
 #include <X11/fonts/font.h>
 #include "closure.h"
 #include <X11/fonts/fontstruct.h>
+#include <X11/fonts/libxfont2.h>
 
 #define NullDIXFontProp ((DIXFontPropPtr)0)
 
 typedef struct _DIXFontProp *DIXFontPropPtr;
-
-extern FPEFunctions *fpe_functions;
-
+#if 0
+static xfont2_fpe_funcs_rec const **fpe_functions;
+#endif
 int FontToXError(int /*err*/);
 
 Bool SetDefaultFont(char * /*defaultfontname*/);

--- a/miext/damage/damage.c
+++ b/miext/damage/damage.c
@@ -1289,7 +1289,7 @@ damageDamageChars(DrawablePtr pDrawable,
 
     BoxRec box;
 
-    QueryGlyphExtents(font, charinfo, n, &extents);
+    xfont2_query_glyph_extents(font, charinfo, n, &extents);
     if (imageblt) {
         if (extents.overallWidth > extents.overallRight)
             extents.overallRight = extents.overallWidth;

--- a/os/utils.c
+++ b/os/utils.c
@@ -617,7 +617,7 @@ ProcessCommandLine(int argc, char *argv[])
 #endif
 	else if ( strcmp( argv[i], "-deferglyphs") == 0)
 	{
-	    if(++i >= argc || !ParseGlyphCachingMode(argv[i]))
+	    if(++i >= argc || !xfont2_parse_glyph_caching_mode(argv[i]))
 		UseMsg();
 	}
 	else if ( strcmp( argv[i], "-f") == 0)


### PR DESCRIPTION
While I could get tinyx to build with linXfont1 installed, I couldn't get tinyx to start on my machine with regular libXfont2 fonts installed.

So I ported tinyx to libXfont2.