### PR TITLE
Port fix for a segfault

### DIFF
--- a/kdrive/linux/mouse.c
+++ b/kdrive/linux/mouse.c
@@ -386,8 +386,7 @@ static const KmouseProt exps2Prot = {
 #define PSM_4DPLUS_ID           8
 
 static const unsigned char ps2_init[] = {
-	PSMC_ENABLE_DEV,
-	0,
+	PSMC_ENABLE_DEV
 };
 
 #define NINIT_PS2   1
@@ -397,7 +396,6 @@ static const unsigned char wheel_3button_init[] = {
 	PSMC_SET_SAMPLING_RATE, 100,
 	PSMC_SET_SAMPLING_RATE, 80,
 	PSMC_SEND_DEV_ID,
-	0,
 };
 
 #define NINIT_IMPS2 4
@@ -410,7 +408,6 @@ static const unsigned char wheel_5button_init[] = {
 	PSMC_SET_SAMPLING_RATE, 200,
 	PSMC_SET_SAMPLING_RATE, 80,
 	PSMC_SEND_DEV_ID,
-	0
 };
 
 #define NINIT_EXPS2 7
@@ -419,7 +416,6 @@ static const unsigned char intelli_init[] = {
 	PSMC_SET_SAMPLING_RATE, 200,
 	PSMC_SET_SAMPLING_RATE, 100,
 	PSMC_SET_SAMPLING_RATE, 80,
-	0
 };
 
 #define NINIT_INTELLI	3
@@ -456,9 +452,10 @@ static Bool ps2Init(KdMouseInfo * mi)
 	int id;
 	const unsigned char *init;
 	int ninit;
+	int len;
 
 	/* Send Intellimouse initialization sequence */
-	MouseWriteBytes(km->iob.fd, intelli_init, strlen((char *)intelli_init),
+	MouseWriteBytes(km->iob.fd, intelli_init, sizeof(intelli_init),
 			100);
 	/*
 	 * Send ID command
@@ -471,20 +468,23 @@ static Bool ps2Init(KdMouseInfo * mi)
 		init = wheel_3button_init;
 		ninit = NINIT_IMPS2;
 		km->prot = &imps2Prot;
+		len = sizeof(wheel_3button_init);
 		break;
 	case 4:
 		init = wheel_5button_init;
 		ninit = NINIT_EXPS2;
 		km->prot = &exps2Prot;
+		len = sizeof(wheel_5button_init);
 		break;
 	default:
 		init = ps2_init;
 		ninit = NINIT_PS2;
 		km->prot = &ps2Prot;
+		len = sizeof(ps2_init);
 		break;
 	}
 	if (init)
-		MouseWriteBytes(km->iob.fd, init, strlen((char *)init), 100);
+		MouseWriteBytes(km->iob.fd, init, len, 100);
 	/*
 	 * Flush out the available data to eliminate responses to the
 	 * initialization string.  Make sure any partial event is

--- a/kdrive/linux/mouse.c
+++ b/kdrive/linux/mouse.c
@@ -729,6 +729,9 @@ static void MouseFirstProtocol(Kmouse * km, char *prot)
 			for (i = 0; i < NUM_PROT; i++)
 				ErrorF(" %s", kmouseProts[i]->name);
 			ErrorF("\n");
+			km->i_prot = 0;
+			km->prot = kmouseProts[km->i_prot];
+			ErrorF("Falling back to %s\n", km->prot->name);
 		} else {
 			km->prot = kmouseProts[km->i_prot];
 			if (km->tty && !km->prot->tty)
@@ -754,7 +757,7 @@ static void MouseNextProtocol(Kmouse * km)
 	do {
 		if (!km->prot)
 			km->i_prot = 0;
-		else if (++km->i_prot == NUM_PROT)
+		else if (++km->i_prot >= NUM_PROT)
 			km->i_prot = 0;
 		km->prot = kmouseProts[km->i_prot];
 	} while (km->prot->tty != km->tty);


### PR DESCRIPTION
This fixes a segfault in the kdrive mouse driver.
I haven't managed to get tinyx to segfault, because the ability to pass mouse protocol by command line args seems to not be implemented.
Still, this doesn't mean that the segfault can't happen here too. It doesn't happen on my system because the default ps/2 protocol works fine for me. However, this might not be the case on other systems.

This code fixes an incorrect loop condition and adds a fallback for unknown mouse protocols.
Also replaces strlen with sizeof appropriately.